### PR TITLE
fix(#30): expand short EO object comments to meet 32-character lint rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 node_modules/
 package-lock.json
 package.json
+.aidy/

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 # SPDX-FileCopyrightText: Copyright (c) 2022-2026 Yegor Bugayenko
 # SPDX-License-Identifier: MIT
 
-EO_VERSION=0.61.1
+EO_VERSION=0.61.2
 HOME_VERSION=$(EO_VERSION)
-EOC_VERSION=0.35.1
+EOC_VERSION=0.35.2
 
 .PHONY: test link install clean all
 .SHELLFLAGS := -e -o pipefail -c

--- a/eo3/aish/program.eo
+++ b/eo3/aish/program.eo
@@ -4,6 +4,6 @@
 +spdx SPDX-License-Identifier: MIT
 +version 0.0.1
 
-# Main program.
+# The main EO program entry point.
 [args] > program
   io.stdout "ready to go\n" > @

--- a/eo3/fit/human.eo
+++ b/eo3/fit/human.eo
@@ -5,7 +5,7 @@
 +spdx SPDX-License-Identifier: MIT
 +version 0.0.1
 
-# Human.
+# A human interacting via stdin/stdout.
 [in out] > human
   malloc.of > name!
     6

--- a/eo3/fit/program.eo
+++ b/eo3/fit/program.eo
@@ -7,7 +7,7 @@
 +version 0.0.1
 +unlint incorrect-number-of-attributes
 
-# Main program.
+# The main EO program entry point.
 [args] > program
   greeting > @
     io.stdout

--- a/eo3/howdy/greeting.eo
+++ b/eo3/howdy/greeting.eo
@@ -4,7 +4,7 @@
 +spdx SPDX-License-Identifier: MIT
 +version 0.0.1
 
-# Greeting.
+# Greets the human with a formatted message.
 [out human] > greeting
   out > @
     tt.sprintf *1

--- a/eo3/howdy/human.eo
+++ b/eo3/howdy/human.eo
@@ -4,7 +4,7 @@
 +spdx SPDX-License-Identifier: MIT
 +version 0.0.1
 
-# Human.
+# A human interacting via stdin/stdout.
 [in out] > human
   seq * > name!
     out "What is your name? "

--- a/eo3/howdy/program.eo
+++ b/eo3/howdy/program.eo
@@ -7,7 +7,7 @@
 +version 0.0.1
 +unlint incorrect-number-of-attributes
 
-# Main program.
+# The main EO program entry point.
 [args] > program
   greeting > @
     io.stdout

--- a/eo3/paranoid/greeting.eo
+++ b/eo3/paranoid/greeting.eo
@@ -4,7 +4,7 @@
 +spdx SPDX-License-Identifier: MIT
 +version 0.0.1
 
-# Greeting.
+# Greets the human with a formatted message.
 [out human] > greeting
   human.name > n!
   out > @

--- a/eo3/paranoid/program.eo
+++ b/eo3/paranoid/program.eo
@@ -7,7 +7,7 @@
 +version 0.0.1
 +unlint incorrect-number-of-attributes
 
-# Main program.
+# The main EO program entry point.
 [args] > program
   greeting > @
     io.stdout

--- a/eo3/pardon/appellation.eo
+++ b/eo3/pardon/appellation.eo
@@ -4,7 +4,7 @@
 +spdx SPDX-License-Identifier: MIT
 +version 0.0.1
 
-# A name entered by a human.
+# A name entered by a human via stdin.
 [in out] > appellation
   seq * > @
     out "What is your name? "

--- a/eo3/pardon/human.eo
+++ b/eo3/pardon/human.eo
@@ -5,7 +5,7 @@
 +spdx SPDX-License-Identifier: MIT
 +version 0.0.1
 
-# Human.
+# A human interacting via stdin/stdout.
 [in out] > human
   malloc.of > name!
     100

--- a/eo3/pardon/program.eo
+++ b/eo3/pardon/program.eo
@@ -7,7 +7,7 @@
 +version 0.0.1
 +unlint incorrect-number-of-attributes
 
-# Main program.
+# The main EO program entry point.
 [args] > program
   greeting > @
     io.stdout

--- a/eo3/parsing-lines/index-of-byte.eo
+++ b/eo3/parsing-lines/index-of-byte.eo
@@ -41,7 +41,7 @@
         "John Malkovich".as-bytes
         "J".as-bytes
 
-  # Finds the second byte.
+  # Finds the second byte in the sequence.
   [] +> finds-second-byte
     assert > @
       1

--- a/eo3/parsing-lines/max.eo
+++ b/eo3/parsing-lines/max.eo
@@ -4,7 +4,7 @@
 +spdx SPDX-License-Identifier: MIT
 +version 0.0.1
 
-# The larger of two numbers.
+# The larger of two given numbers.
 [a b] > max
   if. > @
     b.gt a

--- a/eo3/parsing-lines/min.eo
+++ b/eo3/parsing-lines/min.eo
@@ -4,7 +4,7 @@
 +spdx SPDX-License-Identifier: MIT
 +version 0.0.1
 
-# The smaller of two numbers.
+# The smaller of two given numbers.
 [a b] > min
   if. > @
     a.gt b

--- a/eo3/skeptic/human.eo
+++ b/eo3/skeptic/human.eo
@@ -5,7 +5,7 @@
 +spdx SPDX-License-Identifier: MIT
 +version 0.0.1
 
-# Human.
+# A human interacting via stdin/stdout.
 [in out] > human
   go.to > name!
     [g] >>

--- a/eo3/skeptic/program.eo
+++ b/eo3/skeptic/program.eo
@@ -7,7 +7,7 @@
 +version 0.0.1
 +unlint incorrect-number-of-attributes
 
-# Main program.
+# The main EO program entry point.
 [args] > program
   greeting > @
     io.stdout


### PR DESCRIPTION
Expands all object comments across 16 `.eo` files to satisfy the `comment-too-short` lint rule (minimum 32 characters), and bumps `EO_VERSION` to `0.61.2` and `EOC_VERSION` to `0.35.2`.

Fixes #30