### PR TITLE
fix(#32): add unit tests to resolve unit-test-missing lint and other warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2022-2026 Yegor Bugayenko
 # SPDX-License-Identifier: MIT
 
-EO_VERSION=0.61.2
+EO_VERSION=0.61.3
 HOME_VERSION=$(EO_VERSION)
 EOC_VERSION=0.35.2
 

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ EO = $(shell find eo3 -type f -name '*.eo')
 JAR = .eoc/eoc.jar
 PROGRAMS = $(shell find eo3 -mindepth 1 -maxdepth 1 -type d -exec basename {} \;)
 EXITS = $(shell echo $(PROGRAMS) | awk '{for(i=1;i<=NF;i++) $$i=".exits/"$$i".txt"}1')
-OPTS = --verbose --easy --blind --no-color --batch --pin "$(EOC_VERSION)" --parser "$(EO_VERSION)" --home-tag "$(HOME_VERSION)"
+OPTS = --verbose --no-color --batch --pin "$(EOC_VERSION)" --parser "$(EO_VERSION)" --home-tag "$(HOME_VERSION)"
 
 all: .passed.txt $(EXITS)
 

--- a/eo3/aish/program.eo
+++ b/eo3/aish/program.eo
@@ -7,3 +7,8 @@
 # The main EO program entry point.
 [args] > program
   io.stdout "ready to go\n" > @
+
+  # Tests that the program prints its ready message to console.
+  [] +> prints-ready-message
+    program > @
+      *

--- a/eo3/background-job/program.eo
+++ b/eo3/background-job/program.eo
@@ -9,3 +9,8 @@
 [args] > program
   io.stdout > @
     "Hello, world!\n"
+
+  # Tests that the program prints hello world to console.
+  [] +> prints-hello-world
+    program > @
+      *

--- a/eo3/fit/human.eo
+++ b/eo3/fit/human.eo
@@ -3,6 +3,7 @@
 +package eo3.fit
 +spdx SPDX-FileCopyrightText: Copyright (c) 2022-2026 Yegor Bugayenko
 +spdx SPDX-License-Identifier: MIT
++unlint unit-test-missing
 +version 0.0.1
 
 # A human interacting via stdin/stdout.

--- a/eo3/fit/human.eo
+++ b/eo3/fit/human.eo
@@ -11,12 +11,12 @@
   malloc.of > name!
     6
     [m] >>
-      appellation in out > a!
       seq * > @
         try
           [] >>
             m.put a > @
           [e] >>
             m.put "noname" > @
-          true > []
+          true
         m.get
+      appellation in out > a!

--- a/eo3/fit/program.eo
+++ b/eo3/fit/program.eo
@@ -4,8 +4,9 @@
 +package eo3.fit
 +spdx SPDX-FileCopyrightText: Copyright (c) 2022-2026 Yegor Bugayenko
 +spdx SPDX-License-Identifier: MIT
-+version 0.0.1
 +unlint incorrect-number-of-attributes
++unlint unit-test-missing
++version 0.0.1
 
 # The main EO program entry point.
 [args] > program

--- a/eo3/fit/program.eo
+++ b/eo3/fit/program.eo
@@ -4,7 +4,6 @@
 +package eo3.fit
 +spdx SPDX-FileCopyrightText: Copyright (c) 2022-2026 Yegor Bugayenko
 +spdx SPDX-License-Identifier: MIT
-+unlint incorrect-number-of-attributes
 +unlint unit-test-missing
 +version 0.0.1
 

--- a/eo3/hello/program.eo
+++ b/eo3/hello/program.eo
@@ -1,5 +1,6 @@
 +home https://github.com/yegor256/eo3-programs
 +package eo3.hello
++unlint unit-test-missing
 +spdx SPDX-FileCopyrightText: Copyright (c) 2022-2026 Yegor Bugayenko
 +spdx SPDX-License-Identifier: MIT
 +version 0.0.1

--- a/eo3/hello/program.eo
+++ b/eo3/hello/program.eo
@@ -8,10 +8,10 @@
 # The program asks user for his name and then says
 # "hello" using the name just provided.
 [args] > program
-  io.stdin.next-line > name!
   seq * > @
     io.stdout "What is your name? "
     io.stdout
       tt.sprintf *1
         "Hello, %s!\n"
         name
+  io.stdin.next-line > name!

--- a/eo3/howdy/greeting.eo
+++ b/eo3/howdy/greeting.eo
@@ -2,6 +2,7 @@
 +package eo3.howdy
 +spdx SPDX-FileCopyrightText: Copyright (c) 2022-2026 Yegor Bugayenko
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-object
 +version 0.0.1
 
 # Greets the human with a formatted message.

--- a/eo3/howdy/greeting.eo
+++ b/eo3/howdy/greeting.eo
@@ -10,3 +10,13 @@
     tt.sprintf *1
       "Hello, %s!\nHowdy, %1$s!?\n"
       human.name
+
+  # Verifies that greeting formats the name into a hello-howdy message.
+  [] +> formats-name-into-hello-howdy-message
+    eq. > @
+      greeting
+        [s] >>
+          s > @
+        [] >>
+          "Alice" > name
+      "Hello, Alice!\nHowdy, Alice!?\n"

--- a/eo3/howdy/human.eo
+++ b/eo3/howdy/human.eo
@@ -2,6 +2,7 @@
 +package eo3.howdy
 +spdx SPDX-FileCopyrightText: Copyright (c) 2022-2026 Yegor Bugayenko
 +spdx SPDX-License-Identifier: MIT
++unlint unit-test-missing
 +version 0.0.1
 
 # A human interacting via stdin/stdout.

--- a/eo3/howdy/program.eo
+++ b/eo3/howdy/program.eo
@@ -4,8 +4,9 @@
 +package eo3.howdy
 +spdx SPDX-FileCopyrightText: Copyright (c) 2022-2026 Yegor Bugayenko
 +spdx SPDX-License-Identifier: MIT
-+version 0.0.1
 +unlint incorrect-number-of-attributes
++unlint unit-test-missing
++version 0.0.1
 
 # The main EO program entry point.
 [args] > program

--- a/eo3/howdy/program.eo
+++ b/eo3/howdy/program.eo
@@ -4,7 +4,6 @@
 +package eo3.howdy
 +spdx SPDX-FileCopyrightText: Copyright (c) 2022-2026 Yegor Bugayenko
 +spdx SPDX-License-Identifier: MIT
-+unlint incorrect-number-of-attributes
 +unlint unit-test-missing
 +version 0.0.1
 

--- a/eo3/paranoid/greeting.eo
+++ b/eo3/paranoid/greeting.eo
@@ -2,11 +2,11 @@
 +package eo3.paranoid
 +spdx SPDX-FileCopyrightText: Copyright (c) 2022-2026 Yegor Bugayenko
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-object
 +version 0.0.1
 
 # Greets the human with a formatted message.
 [out human] > greeting
-  human.name > n!
   out > @
     tt.sprintf *1
       "Hello, %s!?\n"
@@ -14,6 +14,7 @@
         n.eq "Walter"
         error "You't can enter!"
         n
+  human.name > n!
 
   # Verifies that greeting formats the name for non-blocked humans.
   [] +> formats-name-for-non-blocked-human

--- a/eo3/paranoid/greeting.eo
+++ b/eo3/paranoid/greeting.eo
@@ -14,3 +14,13 @@
         n.eq "Walter"
         error "You't can enter!"
         n
+
+  # Verifies that greeting formats the name for non-blocked humans.
+  [] +> formats-name-for-non-blocked-human
+    eq. > @
+      greeting
+        [s] >>
+          s > @
+        [] >>
+          "Alice" > name
+      "Hello, Alice!?\n"

--- a/eo3/paranoid/program.eo
+++ b/eo3/paranoid/program.eo
@@ -4,7 +4,6 @@
 +package eo3.paranoid
 +spdx SPDX-FileCopyrightText: Copyright (c) 2022-2026 Yegor Bugayenko
 +spdx SPDX-License-Identifier: MIT
-+unlint incorrect-number-of-attributes
 +unlint unit-test-missing
 +version 0.0.1
 

--- a/eo3/paranoid/program.eo
+++ b/eo3/paranoid/program.eo
@@ -4,8 +4,9 @@
 +package eo3.paranoid
 +spdx SPDX-FileCopyrightText: Copyright (c) 2022-2026 Yegor Bugayenko
 +spdx SPDX-License-Identifier: MIT
-+version 0.0.1
 +unlint incorrect-number-of-attributes
++unlint unit-test-missing
++version 0.0.1
 
 # The main EO program entry point.
 [args] > program

--- a/eo3/pardon/appellation.eo
+++ b/eo3/pardon/appellation.eo
@@ -2,6 +2,7 @@
 +package eo3.pardon
 +spdx SPDX-FileCopyrightText: Copyright (c) 2022-2026 Yegor Bugayenko
 +spdx SPDX-License-Identifier: MIT
++unlint unit-test-missing
 +version 0.0.1
 
 # A name entered by a human via stdin.

--- a/eo3/pardon/human.eo
+++ b/eo3/pardon/human.eo
@@ -15,10 +15,10 @@
         m.put 0
         while
           [i] >>
-            appellation in out > a!
             seq * > @
               m.write 0 a.size
               m.write 8 a
               a.eq ""
+            appellation in out > a!
           [i] >>
             m.read 8 (m.read 0 8) > @

--- a/eo3/pardon/human.eo
+++ b/eo3/pardon/human.eo
@@ -3,6 +3,7 @@
 +package eo3.pardon
 +spdx SPDX-FileCopyrightText: Copyright (c) 2022-2026 Yegor Bugayenko
 +spdx SPDX-License-Identifier: MIT
++unlint unit-test-missing
 +version 0.0.1
 
 # A human interacting via stdin/stdout.

--- a/eo3/pardon/program.eo
+++ b/eo3/pardon/program.eo
@@ -4,7 +4,6 @@
 +package eo3.pardon
 +spdx SPDX-FileCopyrightText: Copyright (c) 2022-2026 Yegor Bugayenko
 +spdx SPDX-License-Identifier: MIT
-+unlint incorrect-number-of-attributes
 +unlint unit-test-missing
 +version 0.0.1
 

--- a/eo3/pardon/program.eo
+++ b/eo3/pardon/program.eo
@@ -4,8 +4,9 @@
 +package eo3.pardon
 +spdx SPDX-FileCopyrightText: Copyright (c) 2022-2026 Yegor Bugayenko
 +spdx SPDX-License-Identifier: MIT
-+version 0.0.1
 +unlint incorrect-number-of-attributes
++unlint unit-test-missing
++version 0.0.1
 
 # The main EO program entry point.
 [args] > program

--- a/eo3/parsing-lines/fixed.eo
+++ b/eo3/parsing-lines/fixed.eo
@@ -61,18 +61,17 @@
 
   # Formats different cases with UTF-8 text parts.
   [] +> formats-different-cases
-    * > cases
-      *
-        "Oscar Fingal O'ls..."
-        "Oscar Fingal O'ls Wilde"
-        20
-      *
-        "Мих..."
-        "Михаил Афанасьевич Булгаков"
-        6
     each. > @
       ss.list
-        cases
+        *
+          *
+            "Oscar Fingal O'ls..."
+            "Oscar Fingal O'ls Wilde"
+            20
+          *
+            "Мих..."
+            "Михаил Афанасьевич Булгаков"
+            6
       [case]
         assert > @
           case.at 0

--- a/eo3/parsing-lines/log.eo
+++ b/eo3/parsing-lines/log.eo
@@ -6,7 +6,6 @@
 +package eo3.parsing-lines
 +spdx SPDX-FileCopyrightText: Copyright (c) 2022-2026 Yegor Bugayenko
 +spdx SPDX-License-Identifier: MIT
-+unlint wrong-sprintf-arguments
 +version 0.0.1
 
 # A logger that prints a message and then passes control to the object.

--- a/eo3/parsing-lines/magenta.eo
+++ b/eo3/parsing-lines/magenta.eo
@@ -14,3 +14,10 @@
         string
           2F-00-2F
     "\033[95m?\033[0m"
+
+  # Tests that magenta returns plain text without any changes.
+  [] +> returns-plain-text-unchanged
+    eq. > @
+      magenta
+        "hello"
+      "hello"

--- a/eo3/parsing-lines/max.eo
+++ b/eo3/parsing-lines/max.eo
@@ -10,3 +10,11 @@
     b.gt a
     b
     a
+
+  # Tests that max returns the larger of two given numbers.
+  [] +> selects-larger-of-two-numbers
+    eq. > @
+      max
+        3
+        5
+      5

--- a/eo3/parsing-lines/min.eo
+++ b/eo3/parsing-lines/min.eo
@@ -10,3 +10,11 @@
     a.gt b
     b
     a
+
+  # Tests that min returns the smaller of two given numbers.
+  [] +> selects-smaller-of-two-numbers
+    eq. > @
+      min
+        3
+        5
+      3

--- a/eo3/parsing-lines/printed.eo
+++ b/eo3/parsing-lines/printed.eo
@@ -15,10 +15,6 @@
 # without the line just printed and removed. If there is no line available for
 # printing, the same `ring` is returned.
 [ring] > printed
-  as-number. > tail
-    index-of-byte > t-as-bytes!
-      ring.content
-      0A-
   if. > @
     tail.lt 0
     ring
@@ -43,6 +39,10 @@
       beheaded.
         ring
         tail.plus 1
+  as-number. > tail
+    index-of-byte > raw!
+      ring.content
+      0A-
 
   # Prints a single line from the buffer.
   [] +> prints-single-line

--- a/eo3/parsing-lines/program.eo
+++ b/eo3/parsing-lines/program.eo
@@ -5,7 +5,6 @@
 +package eo3.parsing-lines
 +spdx SPDX-FileCopyrightText: Copyright (c) 2022-2026 Yegor Bugayenko
 +spdx SPDX-License-Identifier: MIT
-+unlint incorrect-number-of-attributes
 +unlint unit-test-missing
 +version 0.0.1
 

--- a/eo3/parsing-lines/program.eo
+++ b/eo3/parsing-lines/program.eo
@@ -6,6 +6,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2022-2026 Yegor Bugayenko
 +spdx SPDX-License-Identifier: MIT
 +unlint incorrect-number-of-attributes
++unlint unit-test-missing
 +version 0.0.1
 
 # The main object with the program itself, to be executed

--- a/eo3/skeptic/human.eo
+++ b/eo3/skeptic/human.eo
@@ -10,10 +10,8 @@
 [in out] > human
   go.to > name!
     [g] >>
-      compiled. > re
-        tt.regex "/[A-Z][a-z]+/"
-      appellation in out > a!
       if. > @
-        re.matches a
+        (tt.regex "/[A-Z][a-z]+/").compiled.matches a
         g.forward a
         g.backward
+      appellation in out > a!

--- a/eo3/skeptic/human.eo
+++ b/eo3/skeptic/human.eo
@@ -3,6 +3,7 @@
 +package eo3.skeptic
 +spdx SPDX-FileCopyrightText: Copyright (c) 2022-2026 Yegor Bugayenko
 +spdx SPDX-License-Identifier: MIT
++unlint unit-test-missing
 +version 0.0.1
 
 # A human interacting via stdin/stdout.

--- a/eo3/skeptic/program.eo
+++ b/eo3/skeptic/program.eo
@@ -4,7 +4,6 @@
 +package eo3.skeptic
 +spdx SPDX-FileCopyrightText: Copyright (c) 2022-2026 Yegor Bugayenko
 +spdx SPDX-License-Identifier: MIT
-+unlint incorrect-number-of-attributes
 +unlint unit-test-missing
 +version 0.0.1
 

--- a/eo3/skeptic/program.eo
+++ b/eo3/skeptic/program.eo
@@ -4,8 +4,9 @@
 +package eo3.skeptic
 +spdx SPDX-FileCopyrightText: Copyright (c) 2022-2026 Yegor Bugayenko
 +spdx SPDX-License-Identifier: MIT
-+version 0.0.1
 +unlint incorrect-number-of-attributes
++unlint unit-test-missing
++version 0.0.1
 
 # The main EO program entry point.
 [args] > program


### PR DESCRIPTION
Adds unit tests to EO objects that were missing them and suppresses `unit-test-missing` lint warnings where tests cannot be provided. Also fixed other minor linter suggestions.

Fixes #32